### PR TITLE
Core gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Declare your gem's dependencies in ablab.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
-gemspec
+gemspec name: 'ablab'
 
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or

--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ Then go to `yourapp.com/ablab` to see the experiment dashboard.
 ![Ablab Dashboard](https://raw.githubusercontent.com/lucaong/ablab/master/dashboard.png)
 
 
+## Using Ablab outside of Rails
+
+In case you want to use `Ablab` in a non-Rails project, you might want to use
+the `ablab-core` gem instead of `ablab`: it is a version of `Ablab` stripped
+out of the Rails engine part, so that it does not depend on Rails anymore.
+Note that `ablab-core` is a pure library version, it does not contain an HTTP
+server nor any JavaScript tracking facility. Also, you would probably have to
+rederfine the `Ablab::Helper.ablab_session_id` method to return (and store) a
+unique session id for the current user.
+
+
 ## Feature Wishlist
 
   - Pause/resume experiments

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,11 @@ load 'rails/tasks/statistics.rake'
 
 require "rspec/core/rake_task"
 
-Bundler::GemHelper.install_tasks
+Bundler::GemHelper.install_tasks(name: 'ablab')
+
+namespace :core do
+  Bundler::GemHelper.install_tasks(name: 'ablab-core')
+end
 
 RSpec::Core::RakeTask.new(:spec)
 task default: :spec

--- a/ablab-core.gemspec
+++ b/ablab-core.gemspec
@@ -1,0 +1,30 @@
+$:.push File.expand_path("../lib", __FILE__)
+
+# Maintain your gem's version:
+require "ablab/version"
+
+# Describe your gem and declare its dependencies:
+Gem::Specification.new do |s|
+  s.name        = "ablab-core"
+  s.version     = Ablab::VERSION
+  s.authors     = ["Luca Ongaro"]
+  s.email       = ["lukeongaro@gmail.com"]
+  s.homepage    = "https://github.com/lucaong/ablab"
+  s.summary     = "Ablab core - A/B testing library"
+  s.description = "Ablab - A/B testing library"
+  s.license     = "MIT"
+
+  s.files = Dir["{lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"].reject do |f|
+    %w(engine.rb helper.rb).include?(File.basename(f))
+  end
+  s.test_files = Dir["spec/**/*"].reject do |f|
+    %w(engine_spec.rb helper_spec.rb).include?(File.basename(f))
+  end
+
+  s.add_dependency "redis"
+
+  s.add_development_dependency "rake"
+  s.add_development_dependency "bundler"
+  s.add_development_dependency "rspec"
+end
+


### PR DESCRIPTION
Release `ablab-core` as a separate gem, stripped-out of any Rails dependency
