### PR TITLE
add `#if_group` method to `Run`

### DIFF
--- a/lib/ablab.rb
+++ b/lib/ablab.rb
@@ -144,6 +144,10 @@ module Ablab
       @group = experiment.groups[idx]
     end
 
+    def if_group(name)
+      yield if group == name
+    end
+
     def draw
       sid_hash = Digest::SHA1.hexdigest(session_id)[-8..-1].to_i(16)
       exp_hash = Digest::SHA1.hexdigest(experiment.name.to_s)[-8..-1].to_i(16)

--- a/spec/ablab_spec.rb
+++ b/spec/ablab_spec.rb
@@ -244,6 +244,28 @@ describe Ablab do
       end
     end
 
+    describe "#if_group" do
+      before do
+        allow(run).to receive(:group).and_return(Ablab::Group.new(:foo))
+      end
+
+      it "executes block if the run's group is the given one" do
+        called = false
+        run.if_group(:foo) do
+          called = true
+        end
+        expect(called).to be(true)
+      end
+
+      it "does not execute block if the run's group is not the given one" do
+        called = false
+        run.if_group(:bar) do
+          called = true
+        end
+        expect(called).to be(false)
+      end
+    end
+
     describe "#track_view!" do
       it "tracks the view" do
         expect(Ablab.tracker).to receive(:track_view!)


### PR DESCRIPTION
should be preffered to if conditions, because it avoids this problem:

``` ruby
if experiment(:foo).group(:bar)
  # something
else
  # something else. This is wrong because also cases in which
  # group is `nil` will mistakenly fall in this branch
end
```

Instead, this makes it explicit:

``` ruby
experiment(:foo).if_group(:bar) do
  # something
end

experiment(:foo).if_group(:control) do
  # something else
end
```
